### PR TITLE
Add tests, fix a variety of problems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ Reader/Writer streams.
 [dependencies]
 libc = "0.1"
 bzip2-sys = { version = "0.1", path = "bzip2-sys" }
+
+[dev-dependencies]
+rand = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@
 
 extern crate bzip2_sys as ffi;
 extern crate libc;
+#[cfg(test)]
+extern crate rand;
 
 pub mod raw;
 pub mod writer;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -107,7 +107,7 @@ impl<R: Read> Inner<R> {
                 _ => return Err(io::Error::new(io::ErrorKind::InvalidInput,
                                                "invalid input")),
             }
-            if target - read > 0 && !eof { continue }
+            if target > read && !eof { continue }
             return Ok(read)
         }
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -41,6 +41,25 @@ impl<R: Read> BzCompressor<R> {
 
     /// Unwrap the underlying writer, finishing the compression stream.
     pub fn into_inner(self) -> R { self.0.r }
+
+    /// Returns the number of bytes produced by the compressor
+    /// (e.g. the number of bytes read from this stream)
+    ///
+    /// Note that, due to buffering, this only bears any relation to
+    /// total_in() when the compressor chooses to flush its data
+    /// (unfortunately, this won't happen this won't happen in general
+    /// at the end of the stream, because the compressor doesn't know
+    /// if there's more data to come).  At that point,
+    /// `total_out() / total_in()` would be the compression ratio.
+    pub fn total_out(&self) -> u64 {
+        self.0.stream.total_out()
+    }
+
+    /// Returns the number of bytes consumed by the compressor
+    /// (e.g. the number of bytes read from the underlying stream)
+    pub fn total_in(&self) -> u64 {
+        self.0.stream.total_in()
+    }
 }
 
 impl<R: Read> Read for BzCompressor<R> {
@@ -68,6 +87,23 @@ impl<R: Read> BzDecompressor<R> {
 
     /// Unwrap the underlying writer, finishing the compression stream.
     pub fn into_inner(self) -> R { self.0.r }
+
+    /// Returns the number of bytes produced by the decompressor
+    /// (e.g. the number of bytes read from this stream)
+    ///
+    /// Note that, due to buffering, this only bears any relation to
+    /// total_in() when the decompressor reaches a sync point
+    /// (e.g. where the original compressed stream was flushed).
+    /// At that point, `total_in() / total_out()` is the compression ratio.
+    pub fn total_out(&self) -> u64 {
+        self.0.stream.total_out()
+    }
+
+    /// Returns the number of bytes consumed by the decompressor
+    /// (e.g. the number of bytes read from the underlying stream)
+    pub fn total_in(&self) -> u64 {
+        self.0.stream.total_in()
+    }
 }
 
 impl<R: Read> Read for BzDecompressor<R> {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -63,6 +63,16 @@ impl<W: Write> BzCompressor<W> {
         }
         Ok(self.w.take().unwrap())
     }
+
+    /// Returns the number of bytes produced by the compressor
+    pub fn total_out(&self) -> u64 {
+        self.stream.total_out()
+    }
+
+    /// Returns the number of bytes consumed by the compressor
+    pub fn total_in(&self) -> u64 {
+        self.stream.total_in()
+    }
 }
 
 impl<W: Write> Write for BzCompressor<W> {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -77,7 +77,11 @@ impl<W: Write> BzCompressor<W> {
 
 impl<W: Write> Write for BzCompressor<W> {
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-        self.do_write(data, Action::Run)
+        if data.len() != 0 {
+            self.do_write(data, Action::Run)
+        } else {
+            Ok(0)
+        }
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -184,5 +188,15 @@ mod tests {
         assert_eq!(&data[0..5], b"12834");
         assert_eq!(data.len(), 500005);
         assert!(format!("12834{}", s).as_bytes() == &*data);
+    }
+
+    #[test]
+    fn write_empty() {
+        let d = BzDecompressor::new(Vec::new());
+        let mut c = BzCompressor::new(d, ::Compress::Default);
+        c.write(b"").unwrap();
+        let data = c.into_inner().ok().unwrap()
+                    .into_inner().ok().unwrap();
+        assert_eq!(&data[..], b"");
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -65,11 +65,16 @@ impl<W: Write> BzCompressor<W> {
     }
 
     /// Returns the number of bytes produced by the compressor
+    ///
+    /// Note that, due to buffering, this only bears any relation to
+    /// `total_in()` after a call to `flush()`.  At that point,
+    /// `total_out() / total_in()` is the compression ratio.
     pub fn total_out(&self) -> u64 {
         self.stream.total_out()
     }
 
     /// Returns the number of bytes consumed by the compressor
+    /// (e.g. the number of bytes written to this stream.)
     pub fn total_in(&self) -> u64 {
         self.stream.total_in()
     }
@@ -149,6 +154,21 @@ impl<W: Write> BzDecompressor<W> {
             Err(e) => return Err((self, e)),
         }
         Ok(self.w.take().unwrap())
+    }
+
+    /// Returns the number of bytes produced by the decompressor
+    ///
+    /// Note that, due to buffering, this only bears any relation to
+    /// `total_in()` after a call to `flush()`.  At that point,
+    /// `total_in() / total_out()` is the compression ratio.
+    pub fn total_out(&self) -> u64 {
+        self.stream.total_out()
+    }
+
+    /// Returns the number of bytes consumed by the decompressor
+    /// (e.g. the number of bytes written to this stream.)
+    pub fn total_in(&self) -> u64 {
+        self.stream.total_in()
     }
 }
 


### PR DESCRIPTION
I'm not fully confident in the solution here, since I don't understand why it was written the way it was to begin with.  Any pointers on extra tests I could add would be great.

I also added a self_terminating test (checking that the stream will terminate itself, and not try to decompress extra data).  That works fine on master, but I thought I'd leave it in anyway.  I can certainly remove it if you want.