### PR TITLE
Use partial-io to shake out Interrupted-related bugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ futures = { version = "0.1", optional = true }
 
 [dev-dependencies]
 rand = "0.3"
-quickcheck = "0.2"
+partial-io = { version = "^0.2.1", features = ["quickcheck"] }
+quickcheck = "0.4"
 tokio-core = "0.1"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,8 @@ extern crate libc;
 #[cfg(test)]
 extern crate rand;
 #[cfg(test)]
+extern crate partial_io;
+#[cfg(test)]
 extern crate quickcheck;
 #[cfg(feature = "tokio")]
 #[macro_use]


### PR DESCRIPTION
`partial-io` is a helper library that lets users wrap readers and writers and
generate partial reads, or fail with temporary errors like `Interrupted`. It
also integrates with `quickcheck` to provide random sequences of test instances.

`partial-io` found a bug on the write side: we weren't handling `Interrupted`, even
though `AsyncWrite` requires that `Interrupted` errors be handled at this layer.

Closes #19.