### PR TITLE
Enable the x86_64-pc-windows-gnu target on appveyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # bzip2
 
 [![Build Status](https://travis-ci.org/alexcrichton/bzip2-rs.svg?branch=master)](https://travis-ci.org/alexcrichton/bzip2-rs)
-[![Build status](https://ci.appveyor.com/api/projects/status/joowqvvwfhxgdw5x?svg=true)](https://ci.appveyor.com/project/alexcrichton/bzip2-rs)
+[![Build status](https://ci.appveyor.com/api/projects/status/joowqvvwfhxgdw5x/branch/master?svg=true)](https://ci.appveyor.com/project/alexcrichton/bzip2-rs/branch/master)
 
 [Documentation](https://docs.rs/bzip2)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,26 @@
 environment:
   matrix:
   - TARGET: x86_64-pc-windows-msvc
+  - TARGET: x86_64-pc-windows-gnu
   - TARGET: i686-pc-windows-msvc
   - TARGET: i686-pc-windows-gnu
+
 install:
+  - ps: |
+      # For the gnu target we need gcc, provided by mingw. mingw which is already preinstalled,
+      # but we need the right version (32-bit or 64-bit) to the PATH.
+      # See https://www.appveyor.com/docs/build-environment/#mingw-msys-cygwin
+      if ($env:target -like "*-gnu") {
+        if ($env:target -like "x86_64-*") { # x86_64-pc-windows-gnu
+          $env:path = "C:\msys64\mingw64\bin;" + $env:path
+        } else { # i686-pc-windows-gnu
+          $env:path = "C:\mingw\bin;" + $env:path
+        }
+        gcc --version
+      }
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
   - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
   - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
-  - SET PATH=%PATH%;C:\MinGW\bin
   - rustc -V
   - cargo -V
 


### PR DESCRIPTION
After my project failed to build on x86_64-pc-windows-gnu with gcc error in bzip2-sys. I figured out how to fix this with some experimentation based on [zip-rs](https://github.com/mvdnes/zip-rs/blob/master/appveyor.yml) and thought it would be good to document this here directly.