### PR TITLE
MultiBzDecoder: Fix Read trait bound

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -183,9 +183,7 @@ impl<R: Read> MultiBzDecoder<R> {
             inner: bufread::MultiBzDecoder::new(BufReader::new(r)),
         }
     }
-}
 
-impl<R> MultiBzDecoder<R> {
     /// Acquires a reference to the underlying reader.
     pub fn get_ref(&self) -> &R {
         self.inner.get_ref().get_ref()


### PR DESCRIPTION
The implementation of `read::MultiBzDecoder` requires the use of the `Read` trait, but this was not enforced, leading to compile-time errors when used against Rust 1.32.0.

This PR removes the separate `impl` block for `MultiBzDecoder` so that the remaining implementation methods fall under the `Read` impl block.

(n.b. I realised this wasn't an issue after updating to 1.36.0, but I'd already fixed it, so I figured I might as well submit it)