### PR TITLE
Add conversion to std io error and better description

### DIFF
--- a/src/mem.rs
+++ b/src/mem.rs
@@ -301,6 +301,12 @@ impl fmt::Display for Error {
     }
 }
 
+impl From<Error> for std::io::Error {
+    fn from(data: Error) -> std::io::Error {
+        std::io::Error::new(std::io::ErrorKind::Other, data)
+    }
+}
+
 impl Direction for DirCompress {
     unsafe fn destroy(stream: *mut ffi::bz_stream) -> c_int {
         ffi::BZ2_bzCompressEnd(stream)

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -286,7 +286,12 @@ impl<D: Direction> Stream<D> {
 
 impl error::Error for Error {
     fn description(&self) -> &str {
-        "bz2 data error"
+        match self {
+            Error::Sequence => "bzip2: sequence of operations invalid",
+            Error::Data => "bzip2: invalid data",
+            Error::DataMagic => "bzip2: bz2 header missing",
+            Error::Param => "bzip2: invalid parameters",
+        }
     }
 }
 


### PR DESCRIPTION
I'm adding bzip2 support for the async-compression crate, c.f. https://github.com/rustasync/async-compression/pull/45, and therefore I need conversion to `std::io::Error` to reuse  existing generic code.

This PR adds this conversion. And while I was at it, added a more detailed error description.

I would be highly surprised if this breaks anything.

It would be great if this could be merged :smile: 