### PR TITLE
Update minimum version of bzip2-sys to 0.1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["compression", "api-bindings"]
 
 [dependencies]
 libc = "0.2"
-bzip2-sys = { version = "0.1", path = "bzip2-sys" }
+bzip2-sys = { version = "0.1.4", path = "bzip2-sys" }
 tokio-io = { version = "0.1", optional = true }
 futures = { version = "0.1", optional = true }
 


### PR DESCRIPTION
This is the first version of bzip2-sys that successfully compiles with `minimal-versions`.

Attempting to build with `0.1.0` fails while parsing the manifest:

```console
> cargo new --lib foo && cd foo
     Created library `foo` package
> cargo add bzip2
    Updating 'https://github.com/rust-lang/crates.io-index' index
      Adding bzip2 v0.3.3 to dependencies
> cargo generate-lockfile -Z minimal-versions
    Updating crates.io index
> cargo build
  Downloaded libc v0.2.0
  Downloaded bzip2-sys v0.1.0
error: failed to parse manifest at `/Users/nemo157/.cargo/registry/src/github.com-1ecc6299db9ec823/bzip2-sys-0.1.0/Cargo.toml`

Caused by:
  library target names cannot contain hyphens: bzip2-sys
```

Versions from 0.1.1 to 0.1.3 fail because libc v0.1.0 doesn't compile:

```console
> cargo update -p bzip2-sys --precise 0.1.3
    Updating crates.io index
    Updating bzip2-sys v0.1.0 -> v0.1.3
    Updating gcc v0.1.0 -> v0.3.55
> cargo build
   Compiling libc v0.1.0
error: expected identifier, found `"std"`
  --> /Users/nemo157/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.1.0/rust/src/liblibc/lib.rs:76:46
   |
76 | #[cfg(feature = "cargo-build")] extern crate "std" as core;
   |                                              ^^^^^ expected identifier

error: aborting due to previous error

error: could not compile `libc`.

To learn more, run the command again with --verbose.
```

v0.1.4 is the first one to successfully compile:

```console
> cargo update -p bzip2-sys --precise 0.1.4
    Updating crates.io index
    Updating bzip2-sys v0.1.3 -> v0.1.4
    Removing libc v0.1.0
> cargo build 
    [...]
    Finished dev [unoptimized + debuginfo] target(s) in 7.74s
```