### PR TITLE
[bzip2-sys] use the system bzip2 if found via pkg-config

### DIFF
--- a/bzip2-sys/Cargo.toml
+++ b/bzip2-sys/Cargo.toml
@@ -22,4 +22,5 @@ path = "lib.rs"
 libc = "0.2"
 
 [build-dependencies]
+pkg-config = "0.3.9"
 cc = "1.0"

--- a/bzip2-sys/build.rs
+++ b/bzip2-sys/build.rs
@@ -13,7 +13,11 @@ fn main() {
         cfg.define("_WIN32", None);
         cfg.define("BZ_EXPORT", None);
     } else {
-        if pkg_config::Config::new().cargo_metadata(true).probe("bzip2").is_ok() {
+        if pkg_config::Config::new()
+            .cargo_metadata(true)
+            .probe("bzip2")
+            .is_ok()
+        {
             return;
         }
     }

--- a/bzip2-sys/build.rs
+++ b/bzip2-sys/build.rs
@@ -1,15 +1,21 @@
 extern crate cc;
+extern crate pkg_config;
 
 use std::path::PathBuf;
 use std::{env, fs};
 
 fn main() {
     let mut cfg = cc::Build::new();
+    let target = env::var("TARGET").unwrap();
     cfg.warnings(false);
 
-    if env::var("TARGET").unwrap().contains("windows") {
+    if target.contains("windows") {
         cfg.define("_WIN32", None);
         cfg.define("BZ_EXPORT", None);
+    } else {
+        if pkg_config::Config::new().cargo_metadata(true).probe("bzip2").is_ok() {
+            return;
+        }
     }
 
     let dst = PathBuf::from(env::var_os("OUT_DIR").unwrap());


### PR DESCRIPTION
Similar approach to libz-sys: https://github.com/rust-lang/libz-sys/blob/master/build.rs

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alexcrichton/bzip2-rs/58)
<!-- Reviewable:end -->
