### PR TITLE
bzip2-sys: link license texts

### DIFF
--- a/bzip2-sys/LICENSE-APACHE
+++ b/bzip2-sys/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/bzip2-sys/LICENSE-MIT
+++ b/bzip2-sys/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Link license texts so they can be bundled when packaging for Linux distributions e.g. Fedora

```
bzip2-rs/bzip2-sys on  add-bzip2-sys-license is 📦 v0.1.9+1.0.8 via 🦀 v1.43.0
❯ cargo package
   Packaging bzip2-sys v0.1.9+1.0.8 (/home/michel/src/github/alexchrichton/bzip2-rs/bzip2-sys)
   Verifying bzip2-sys v0.1.9+1.0.8 (/home/michel/src/github/alexchrichton/bzip2-rs/bzip2-sys)
    Updating crates.io index
  Downloaded libc v0.2.71
   Compiling libc v0.2.71
   Compiling pkg-config v0.3.17
   Compiling cc v1.0.54
   Compiling bzip2-sys v0.1.9+1.0.8 (/home/michel/src/github/alexchrichton/bzip2-rs/target/package/bzip2-sys-0.1.9+1.0.8)
    Finished dev [unoptimized + debuginfo] target(s) in 6.27s

bzip2-rs/bzip2-sys on  add-bzip2-sys-license is 📦 v0.1.9+1.0.8 via 🦀 v1.43.0
❯ tar tf ../target/package/bzip2-sys-0.1.9+1.0.8.crate | grep LICENSE
bzip2-sys-0.1.9+1.0.8/LICENSE-APACHE
bzip2-sys-0.1.9+1.0.8/LICENSE-MIT
bzip2-sys-0.1.9+1.0.8/bzip2-1.0.8/LICENSE
```

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alexcrichton/bzip2-rs/59)
<!-- Reviewable:end -->
