### PR TITLE
Fix compilation on Wasm

### DIFF
--- a/bzip2-sys/lib.rs
+++ b/bzip2-sys/lib.rs
@@ -48,7 +48,7 @@ macro_rules! abi_compat {
         extern "system" {
             $(pub fn $name($($arg: $t),*) -> $ret;)*
         }
-        #[cfg(not(windows)]
+        #[cfg(not(windows))]
         extern {
             $(pub fn $name($($arg: $t),*) -> $ret;)*
         }

--- a/bzip2-sys/lib.rs
+++ b/bzip2-sys/lib.rs
@@ -48,7 +48,7 @@ macro_rules! abi_compat {
         extern "system" {
             $(pub fn $name($($arg: $t),*) -> $ret;)*
         }
-        #[cfg(any(unix, target_os = "redox"))]
+        #[cfg(not(windows)]
         extern {
             $(pub fn $name($($arg: $t),*) -> $ret;)*
         }


### PR DESCRIPTION
Fix compilation on WebAssembly, as well as any other non-Windows/Unix/Redox targets.

Previously, the functions would be undefined on those targets and the crate would fail to compile with errors like:
```rust
error[E0425]: cannot find function, tuple struct or tuple variant `BZ2_bzCompressInit` in crate `ffi`
   --> src/mem.rs:124:22
    |
124 |                 ffi::BZ2_bzCompressInit(&mut *raw, lvl.level() as c_int, 0, work_factor as c_int),
    |                      ^^^^^^^^^^^^^^^^^^ not found in `ffi`

error[E0425]: cannot find function, tuple struct or tuple variant `BZ2_bzCompress` in crate `ffi`
   --> src/mem.rs:157:24
    |
157 |             match ffi::BZ2_bzCompress(&mut *self.inner.raw, action as c_int) {
    |                        ^^^^^^^^^^^^^^ not found in `ffi`

error[E0425]: cannot find function, tuple struct or tuple variant `BZ2_bzDecompressInit` in crate `ffi`
   --> src/mem.rs:215:29
    |
215 |             assert_eq!(ffi::BZ2_bzDecompressInit(&mut *raw, 0, small as c_int), 0);
    |                             ^^^^^^^^^^^^^^^^^^^^ not found in `ffi`

error[E0425]: cannot find function, tuple struct or tuple variant `BZ2_bzDecompress` in crate `ffi`
   --> src/mem.rs:232:24
    |
232 |             match ffi::BZ2_bzDecompress(&mut *self.inner.raw) {
    |                        ^^^^^^^^^^^^^^^^ not found in `ffi`

error[E0425]: cannot find function, tuple struct or tuple variant `BZ2_bzCompressEnd` in crate `ffi`
   --> src/mem.rs:312:14
    |
312 |         ffi::BZ2_bzCompressEnd(stream)
    |              ^^^^^^^^^^^^^^^^^ not found in `ffi`

error[E0425]: cannot find function, tuple struct or tuple variant `BZ2_bzDecompressEnd` in crate `ffi`
   --> src/mem.rs:317:14
    |
317 |         ffi::BZ2_bzDecompressEnd(stream)
    |              ^^^^^^^^^^^^^^^^^^^ not found in `ffi`
```