### PR TITLE
Enable feature parallel on build-dep cc

### DIFF
--- a/bzip2-sys/Cargo.toml
+++ b/bzip2-sys/Cargo.toml
@@ -23,7 +23,7 @@ libc = "0.2"
 
 [build-dependencies]
 pkg-config = "0.3.9"
-cc = "1.0"
+cc = { version = "1.0", features = ["parallel"] }
 
 [features]
 # Enable this feature if you want to have a statically linked bzip2


### PR DESCRIPTION
This reduce compilation time of `cargo b --release --features static` from 4.83s => 1.94s on M1.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>