### PR TITLE
Optimize build for `libbz2.a`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ tokio-core = "0.1"
 tokio = ["tokio-io", "futures"]
 # Enable this feature if you want to have a statically linked bzip2
 static = ["bzip2-sys/static"]
+
+fat-lto = ["bzip2-sys/fat-lto"]
+thin-lto = ["bzip2-sys/thin-lto"]

--- a/bzip2-sys/Cargo.toml
+++ b/bzip2-sys/Cargo.toml
@@ -28,3 +28,6 @@ cc = "1.0"
 [features]
 # Enable this feature if you want to have a statically linked bzip2
 static = []
+
+fat-lto = [] # Enable fat-lto, will override thin-lto if specified
+thin-lto = [] # Enable thin-lto, will fallback to fat-lto if not supported

--- a/bzip2-sys/build.rs
+++ b/bzip2-sys/build.rs
@@ -25,6 +25,12 @@ fn main() {
 
     let dst = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
+    cfg.flag_if_supported("-ffunction-sections")
+        .flag_if_supported("-fdata-sections")
+        .flag_if_supported("-fmerge-all-constants")
+        .flag_if_supported("-Wl,--gc-sections")
+        .flag_if_supported("-Wl,--icf=safe");
+
     cfg.include("bzip2-1.0.8")
         .define("_FILE_OFFSET_BITS", Some("64"))
         .define("BZ_NO_STDIO", None)

--- a/bzip2-sys/build.rs
+++ b/bzip2-sys/build.rs
@@ -31,6 +31,16 @@ fn main() {
         .flag_if_supported("-Wl,--gc-sections")
         .flag_if_supported("-Wl,--icf=safe");
 
+    if cfg!(feature = "fat-lto") {
+        cfg.flag_if_supported("-flto");
+    } else if cfg!(feature = "thin-lto") {
+        if cfg.is_flag_supported("-flto=thin").unwrap_or(false) {
+            cfg.flag("-flto=thin");
+        } else {
+            cfg.flag_if_supported("-flto");
+        }
+    }
+
     cfg.include("bzip2-1.0.8")
         .define("_FILE_OFFSET_BITS", Some("64"))
         .define("BZ_NO_STDIO", None)


### PR DESCRIPTION
 -  Use `--gc-sections` to remove unused symbols from `libbz2.a`
 -  Add new feature `fat-lto` & `thin-lto`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>