### PR TITLE
update `partial_io` to version `0.5.4`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,8 @@ futures = { version = "0.1", optional = true }
 
 [dev-dependencies]
 rand = "0.8"
-partial-io = { version = "0.3", features = ["quickcheck"] }
+partial-io = { version = "0.5.4", features = ["quickcheck1"] }
 quickcheck = "1.0"
-quickcheck6 = { version = "0.6", package = "quickcheck" }
 tokio-core = "0.1"
 
 [features]

--- a/src/read.rs
+++ b/src/read.rs
@@ -233,7 +233,8 @@ impl<R: AsyncWrite + AsyncRead> AsyncWrite for MultiBzDecoder<R> {
 
 #[cfg(test)]
 mod tests {
-    use partial_io::{GenInterrupted, PartialRead, PartialWithErrors};
+    use partial_io::quickcheck_types::{GenInterrupted, PartialWithErrors};
+    use partial_io::PartialRead;
     use rand::distributions::Standard;
     use rand::{thread_rng, Rng};
     use read::{BzDecoder, BzEncoder, MultiBzDecoder};
@@ -366,7 +367,7 @@ mod tests {
 
     #[test]
     fn qc_partial() {
-        quickcheck6::quickcheck(test as fn(_, _, _) -> _);
+        ::quickcheck::quickcheck(test as fn(_, _, _) -> _);
 
         fn test(
             v: Vec<u8>,

--- a/src/write.rs
+++ b/src/write.rs
@@ -315,7 +315,8 @@ impl<W: Write> Drop for BzDecoder<W> {
 #[cfg(test)]
 mod tests {
     use super::{BzDecoder, BzEncoder};
-    use partial_io::{GenInterrupted, PartialWithErrors, PartialWrite};
+    use partial_io::quickcheck_types::{GenInterrupted, PartialWithErrors};
+    use partial_io::PartialWrite;
     use std::io::prelude::*;
     use std::iter::repeat;
 
@@ -355,7 +356,7 @@ mod tests {
 
     #[test]
     fn qc_partial() {
-        quickcheck6::quickcheck(test as fn(_, _, _) -> _);
+        quickcheck::quickcheck(test as fn(_, _, _) -> _);
 
         fn test(
             v: Vec<u8>,


### PR DESCRIPTION
This removes the double dependency on 2 versions of quickcheck, and updates the version of `rand` that can be used. Only newer versions of `rand` work with the wasm targets.

in combination with https://github.com/alexcrichton/bzip2-rs/pull/89 and by using our pure rust fully compatible implementation of bzip2 https://github.com/trifectatechfoundation/libbzip2-rs we can just run the tests with wasmtime

```
> cargo test --no-default-features --features="libbzip2-rs-sys" --target wasm32-wasip1
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.01s
     Running unittests src/lib.rs (target/wasm32-wasip1/debug/deps/bzip2-4323b5447be16c4a.wasm)

running 15 tests
test bufread::tests::bug_61 ... ok
test read::tests::empty ... ok
test read::tests::multistream_read_till_eof ... ok
test read::tests::qc ... ok
test read::tests::qc_partial ... ok
test read::tests::self_terminating ... ok
test read::tests::smoke ... ok
test read::tests::smoke2 ... ok
test read::tests::smoke3 ... ok
test read::tests::zero_length_read_at_eof ... ok
test read::tests::zero_length_read_with_data ... ok
test write::tests::qc ... ok
test write::tests::qc_partial ... ok
test write::tests::smoke ... ok
test write::tests::write_empty ... ok
```

The msrv of the latest version is [1.56](https://github.com/sunshowers-code/partial-io?tab=readme-ov-file#minimum-supported-rust-version), which is over 3 years old now. Also, the potential msrv bump is just for running the tests, so I don't think it's a problem.
