### PR TITLE
support `libbz2-rs-sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ categories = ["compression", "api-bindings"]
 
 [dependencies]
 libc = "0.2"
-bzip2-sys = { version = "0.1.11", path = "bzip2-sys" }
+bzip2-sys = { version = "0.1.11", path = "bzip2-sys", optional = true }
+libbz2-rs-sys = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
 rand = "0.8"
@@ -26,5 +27,9 @@ partial-io = { version = "0.5.4", features = ["quickcheck1"] }
 quickcheck = "1.0"
 
 [features]
+default = ["dep:bzip2-sys"]
+# Use `libbz2-rs-sys` instead of the C FFI bindings of `bzip2-sys`
+# Using the rust implementation is always static
+libbz2-rs-sys = ["dep:libbz2-rs-sys", "static"]
 # Enable this feature if you want to have a statically linked bzip2
-static = ["bzip2-sys/static"]
+static = ["bzip2-sys?/static"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,10 @@
 #![deny(missing_docs)]
 #![doc(html_root_url = "https://docs.rs/bzip2/")]
 
+#[cfg(not(feature = "libbz2-rs-sys"))]
 extern crate bzip2_sys as ffi;
+#[cfg(feature = "libbz2-rs-sys")]
+extern crate libbz2_rs_sys as ffi;
 extern crate libc;
 #[cfg(test)]
 extern crate partial_io;


### PR DESCRIPTION
Adds a feature flag that uses [`libbz2-rs-sys`](https://crates.io/crates/libbz2-rs-sys) instead of `bzip2-sys`. The `libbz2-rs-sys` crate is a pure rust translation/implementation of stock bzip2. It is 100% compatible with stock bzip2. 

Some notes:

- Cross-compilation (e.g. to wasm) should be much easier than with the C FFI
- Rust code is always linked statically (until we get a stable ABI, which is not close)
- When used as a rust crate, the rust global allocator is used for all memory allocation by default
- Our MSRV is pretty high right now. We can try to drop that a bit but e.g. `let else` is really convenient. The MSRV is unchanged with default settings.

I've not yet added any documentation (perhaps even the static feature flag deserves a mention somewhere). I've also not adjusted CI. Let me know what you want to see there (if anything).