### PR TITLE
make `bz_internal_error` an `extern fn`

### DIFF
--- a/bzip2-sys/lib.rs
+++ b/bzip2-sys/lib.rs
@@ -69,6 +69,6 @@ abi_compat! {
 }
 
 #[no_mangle]
-pub fn bz_internal_error(errcode: c_int) {
+pub extern "C" fn bz_internal_error(errcode: c_int) {
     panic!("bz internal error: {}", errcode);
 }


### PR DESCRIPTION
We're treating this as a soundness fix. While currently using the rust ABI happens to work, it might (in theory) break at any point in the future.

Technically this is breaking semver compatibility, but we believe this will not be observed by any of our users.Bumping the MSRV of a `-sys` crate causes a lot of duplicate dependencies and ecosystem churn, so it's something that we'd rather avoid.