### PR TITLE
Exclude development scripts from published package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,9 @@ jobs:
     - name: Run cargo test (bzip2-sys)
       run: cargo test --no-default-features --features bzip2-sys
       if: matrix.build != 'wasm32'
+    - name: Verify that all necessary files are included for bzip2-sys
+      run: cargo package -p bzip2-sys
+      if: matrix.build != 'wasm32' 
 
   rustfmt:
     name: Rustfmt

--- a/bzip2-sys/Cargo.toml
+++ b/bzip2-sys/Cargo.toml
@@ -13,6 +13,24 @@ Bindings to libbzip2 for bzip2 compression and decompression exposed as
 Reader/Writer streams.
 """
 categories = ["external-ffi-bindings"]
+include = [
+    "README.md",
+    "lib.rs",
+    "LICENSE-MIT",
+    "LICENSE-APACHE",
+    "build.rs",
+    "bzip2-1.0.8/blocksort.c",
+    "bzip2-1.0.8/huffman.c",
+    "bzip2-1.0.8/crctable.c",
+    "bzip2-1.0.8/randtable.c",
+    "bzip2-1.0.8/compress.c",
+    "bzip2-1.0.8/decompress.c",
+    "bzip2-1.0.8/bzlib.c",
+    "bzip2-1.0.8/include/bzlib.h",
+    "bzip2-1.0.8/bzlib.h",
+    "bzip2-1.0.8/bzlib_private.h",
+    "bzip2-1.0.8/LICENSE",
+]
 
 [lib]
 name = "bzip2_sys"


### PR DESCRIPTION
During a dependency review we noticed that the bzip2-sys crate includes various development scripts. These development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from being included in the published packages to make sure that everything that's included is an conscious choice.